### PR TITLE
[APOLLO] mixer_paths: Fix path for voicemmode1-call headphones

### DIFF
--- a/rootdir/vendor/etc/mixer_paths.xml
+++ b/rootdir/vendor/etc/mixer_paths.xml
@@ -1607,8 +1607,7 @@
     </path>
 
     <path name="voicemmode1-call headphones">
-        <ctl name="SLIM_6_RX_Voice Mixer VoiceMMode1" value="1" />
-        <ctl name="VoiceMMode1_Tx Mixer SLIM_0_TX_MMode1" value="1" />
+        <path name="voicemmode1-call" />
     </path>
 
     <path name="voicemmode1-call bt-sco">


### PR DESCRIPTION
The headphones are using interface SLIMBUS_0.
Fix the path to get in-call audio on wired headphones.