### PR TITLE
rootdir: Move uinput-fpc.kl from platform

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -58,6 +58,10 @@ PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/vendor/firmware/touch_module_id_0x30.img:$(TARGET_COPY_OUT_VENDOR)/firmware/touch_module_id_0x30.img \
     $(DEVICE_PATH)/vendor/firmware/touch_module_id_0x31.img:$(TARGET_COPY_OUT_VENDOR)/firmware/touch_module_id_0x31.img
 
+# FPC Gestures
+PRODUCT_COPY_FILES += \
+    $(DEVICE_PATH)/vendor/usr/keylayout/uinput-fpc.kl:$(TARGET_COPY_OUT_VENDOR)/usr/keylayout/uinput-fpc.kl
+
 # Device Init
 PRODUCT_PACKAGES += \
     fstab.apollo \

--- a/rootdir/vendor/usr/keylayout/uinput-fpc.kl
+++ b/rootdir/vendor/usr/keylayout/uinput-fpc.kl
@@ -1,0 +1,19 @@
+# Apollo's sensor is rotated 90 degrees clockwise compared to other Tama
+# devices.
+# So swiping left actually reports a "down" gesture from the FPC HAL.
+# For Apollo, however, left and right are *not* swapped.
+
+key 108   SYSTEM_NAVIGATION_LEFT
+key 103   SYSTEM_NAVIGATION_RIGHT
+key 106   SYSTEM_NAVIGATION_UP
+key 105   SYSTEM_NAVIGATION_DOWN
+
+# Apollo, as seen from the front
+#
+#            106
+#             ^
+#             |
+#    108 <----|----> 103
+#             |
+#             v
+#            105


### PR DESCRIPTION
Apollo's fingerprint sensor is rotated 90 degrees clockwise, as compared to Akari and Akatsuki.

This necessitates two different config files, and as such, the keylayout configs are moved to the individual device gits.