### PR TITLE
[master] vendor: etc: libnfc-nxp: Switch device node to PN553

### DIFF
--- a/rootdir/vendor/etc/libnfc-nxp.conf
+++ b/rootdir/vendor/etc/libnfc-nxp.conf
@@ -20,7 +20,7 @@ NFC_DEBUG_ENABLED=0
 
 ###############################################################################
 # Nfc Device Node name
-NXP_NFC_DEV_NODE="/dev/pn54x"
+NXP_NFC_DEV_NODE="/dev/pn553"
 
 ###############################################################################
 # Extension for Mifare reader enable


### PR DESCRIPTION
Apollo device uses PN553 NFC chip and can work with PN553 driver
accordingly without any problems. Switch to this driver.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>